### PR TITLE
OTC-641: Added time restriction for renewal and activated policies

### DIFF
--- a/policy_notification/apps.py
+++ b/policy_notification/apps.py
@@ -35,7 +35,9 @@ DEFAULT_CONFIG = {
     "trigger_first_call_hour": 8,
     "trigger_last_call_hour": 20,
     "reminder_before_expiry_days": 14,
-    "reminder_after_expiry_days": 5
+    "reminder_after_expiry_days": 5,
+    "policy_activation_relevance_maximum_days_timedelta": 5,
+    "policy_renewal_relevance_maximum_days_timedelta": 5,
 }
 
 logger = logging.getLogger(__name__)
@@ -57,6 +59,8 @@ class PolicyNotificationConfig(AppConfig):
     trigger_last_call_hour = None
     reminder_before_expiry_days = None
     reminder_after_expiry_days = None
+    policy_activation_relevance_maximum_days_timedelta = None
+    policy_renewal_relevance_maximum_days_timedelta = None
 
     def _configure_perms(self, cfg):
         PolicyNotificationConfig.providers = cfg["providers"]
@@ -66,6 +70,10 @@ class PolicyNotificationConfig(AppConfig):
         self.__load_trigger_scheduled_config(cfg)
         PolicyNotificationConfig.reminder_before_expiry_days = cfg['reminder_before_expiry_days']
         PolicyNotificationConfig.reminder_after_expiry_days = cfg['reminder_after_expiry_days']
+        PolicyNotificationConfig.policy_activation_relevance_maximum_days_timedelta =\
+            cfg['policy_activation_relevance_maximum_days_timedelta']
+        PolicyNotificationConfig.policy_renewal_relevance_maximum_days_timedelta = \
+            cfg['policy_renewal_relevance_maximum_days_timedelta']
 
     def ready(self):
         from core.models import ModuleConfiguration

--- a/policy_notification/notification_eligibility_validators/abstract_validator.py
+++ b/policy_notification/notification_eligibility_validators/abstract_validator.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import TypeVar, Callable, Union
+from typing import TypeVar, Callable, Union, Iterable
 
 from django.db.models import Prefetch
 
 from policy_notification.models import IndicationOfPolicyNotifications, IndicationOfPolicyNotificationsDetails
-from policy_notification.notification_eligibility_validators.dataclasses import IneligibleObject
+from policy_notification.notification_eligibility_validators.dataclasses import IneligibleObject, ValidationDefinition
 
 
 class AbstractEligibilityValidator(ABC):
@@ -14,24 +14,11 @@ class AbstractEligibilityValidator(ABC):
 
     @property
     def valid_collection(self):
-        if self._eligible_collection is None:
-            raise ValueError(
-                "Collection was not yet validated. Call validate_notification_eligibility before "
-                "accessing valid_collection."
-            )
-        else:
-            return self._eligible_collection
+        return self._eligible_collection
 
     @property
     def invalid_collection(self):
-        if self._ineligible_collection is None:
-            raise ValueError(
-                "Collection was not yet validated. Call validate_notification_eligibility before "
-                "accessing invalid_collection."
-            )
-        else:
-            self._assert_invalid_collection()
-            return self._ineligible_collection
+        return self._ineligible_collection
 
     def __init__(self, notification_collection: NotificationCollection, type_of_notification: str):
         """
@@ -42,43 +29,30 @@ class AbstractEligibilityValidator(ABC):
         """
         self.notification_collection = notification_collection
         self.type_of_notification = type_of_notification
-        self._eligible_collection = self._DEFAULT_COLLECTION.copy()
-        self._ineligible_collection = self._DEFAULT_COLLECTION.copy()
+        self._eligible_collection, self._ineligible_collection = None, None
+        self.reset_collections()
 
     def validate_notification_eligibility(self):
         """
         For given collection return objects that passed validation.
         If notification for given type was not implemented then return whole collection.
         """
-        self._eligible_collection = self._DEFAULT_COLLECTION.copy()
-        self._ineligible_collection = self._DEFAULT_COLLECTION.copy()
-        notification_collection, type_of_notification = self.notification_collection, self.type_of_notification
-        base_validated = self.__base_validation(notification_collection, type_of_notification)
-        validated = self.__notification_type_validation(base_validated, type_of_notification)
+        validated = self.notification_collection
+        for validation in self.registered_validations:
+            validated = self._perform_validation(validated, validation)
         self._eligible_collection = validated
         self._handle_not_valid_entries()
 
+    @property
     @abstractmethod
-    def _get_validation_for_notification_type(self, notification_type: str) \
-            -> Union[Callable[[NotificationCollection], NotificationCollection], None]:
-        """
-        For given notification type returns function that'll validate NotificationCollection (e.g. Queryset of policies)
-        in context of specific notification type.
-        :param notification_type: Type of notification
-        :return: Function that takes notification collection as argument and returns entries from this collection.
-        """
-        raise NotImplementedError("Has to be implemented")
+    def registered_validations(self) -> Iterable[ValidationDefinition]:
+        ...
 
-    @abstractmethod
-    def _base_eligibility_validation(self, notification_collection: NotificationCollection, type_of_notification: str) \
-            -> NotificationCollection:
-        """
-        Generic validation which is applicable regardless of the specific type of notification.
-        E.g. Check if family allows notification or if notification was already sent.
-        :param notification_collection: Input from validate_notification_eligibility
-        :return Valid entries from policies
-        """
-        raise NotImplementedError("Has to be implemented")
+    def _perform_validation(self, notification_collection, validation_definition: ValidationDefinition):
+        valid = validation_definition.validation_function(notification_collection, self.type_of_notification)
+        not_valid = self._substract_collections(notification_collection, valid)
+        self._collect_not_valid_information(not_valid, validation_definition)
+        return valid
 
     @abstractmethod
     def _handle_not_valid_entries(self):
@@ -90,16 +64,12 @@ class AbstractEligibilityValidator(ABC):
         """
         raise NotImplementedError("Has to be implemented")
 
-    def _add_non_eligible_due_to_notification_type_validation(self, collection):
-        raise NotImplementedError("Hast to be implemented")
+    def _collect_not_valid_information(self, collection, validation_definition: ValidationDefinition):
+        self._ineligible_collection.extend([
+            self._create_ineligible(element, validation_definition) for element in collection
+        ])
 
-    def _add_non_eligible(self, collection, reason):
-        raise NotImplementedError("Hast to be implemented")
-
-    def _assert_invalid_collection(self):
-        pass
-
-    def _add_non_eligible_due_to_base_validation(self, not_valid):
+    def _create_ineligible(self, ineligible, validation_definition: ValidationDefinition):
         raise NotImplementedError()
 
     def _substract_collections(self, collection_from, collection):
@@ -111,44 +81,12 @@ class AbstractEligibilityValidator(ABC):
         """
         raise NotImplementedError()
 
-    def __base_validation(self, notification_collection, type_of_notification):
-        base_validated = self._base_eligibility_validation(notification_collection, type_of_notification)
-        not_valid = self._substract_collections(notification_collection, base_validated)
-        self._add_non_eligible_due_to_base_validation(not_valid)
-        return base_validated
-
-    def __notification_type_validation(self, notification_collection, type_of_notification):
-        validation_func = self._get_validation_for_notification_type(type_of_notification)
-        valid = validation_func(notification_collection) if validation_func else notification_collection
-        not_valid = self._substract_collections(notification_collection, valid)
-        self._add_non_eligible_due_to_notification_type_validation(not_valid)
-
-        return valid
+    def reset_collections(self):
+        self._eligible_collection = self._DEFAULT_COLLECTION.copy()
+        self._ineligible_collection = self._DEFAULT_COLLECTION.copy()
 
 
 class QuerysetEligibilityValidationMixin:
-    BASE_VALIDATION_REJECTION_REASON = None
-    TYPE_VALIDATION_REJECTION_REASON = None
-    TYPE_VALIDATION_REJECTION_DETAILS = None
-
-    def _add_non_eligible_due_to_base_validation(self, not_valid):
-        self._add_non_eligible(not_valid, self.BASE_VALIDATION_REJECTION_REASON)
-
-    def _add_non_eligible_due_to_notification_type_validation(self, not_valid):
-        self._add_non_eligible(not_valid, self.TYPE_VALIDATION_REJECTION_REASON, self.TYPE_VALIDATION_REJECTION_DETAILS)
-
     def _substract_collections(self, collection_from, collection):
         x = collection.values('id')
         return collection_from.exclude(id__in=x).all()
-
-    def _add_non_eligible(self, collection, reason, detail=None):
-        futures = []
-        with ThreadPoolExecutor(max_workers=100) as executor:
-            for element in collection:
-                futures.append(executor.submit(self.__create_ineligible, element, reason, detail))
-
-            completed = as_completed(futures)
-            self._ineligible_collection.extend([f.result() for f in completed])
-
-    def __create_ineligible(self, ineligible, reason, detail):
-        return IneligibleObject(policy=ineligible, reason=reason, details=detail)

--- a/policy_notification/notification_eligibility_validators/dataclasses.py
+++ b/policy_notification/notification_eligibility_validators/dataclasses.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
+from typing import Callable, Any, Collection
 
 from policy.models import Policy
 from policy_notification.models import IndicationOfPolicyNotificationsDetails
 
 
-@dataclass()
+@dataclass
 class IneligibleObject:
     policy: Policy
     reason: int = 0
@@ -18,3 +19,9 @@ class IneligibleObject:
                 'details': self.details
         })
 
+
+@dataclass
+class ValidationDefinition:
+    error_type_code: int  # Should align with IndicationOfPolicyNotificationsDetails.SendIndicationStatus
+    validation_details: str
+    validation_function: Callable[[Collection, str], Collection]

--- a/policy_notification/notification_eligibility_validators/notification_eligibility_validation.py
+++ b/policy_notification/notification_eligibility_validators/notification_eligibility_validation.py
@@ -1,18 +1,18 @@
 import logging
-from datetime import datetime
-from typing import Callable, Union, Type
+from datetime import datetime, timedelta
+from typing import Type
 
 from django.db.models import Prefetch
-from django_mysql.models import QuerySet
-from policy.models import Policy
 from policy_notification.apps import PolicyNotificationConfig
 from policy_notification.models import IndicationOfPolicyNotifications, IndicationOfPolicyNotificationsDetails
 from policy_notification.notification_eligibility_validators.abstract_validator import AbstractEligibilityValidator, \
     QuerysetEligibilityValidationMixin
 from django.db.models.query_utils import Q
 
+from policy_notification.notification_eligibility_validators.dataclasses import IneligibleObject, ValidationDefinition
 from policy_notification.notification_eligibility_validators.not_eligible_notification_handler import \
     NotEligibleNotificationHandler
+from policy_notification.utils import get_notification_indication_filter
 
 logger = logging.getLogger(__name__)
 
@@ -20,73 +20,69 @@ logger = logging.getLogger(__name__)
 class PolicyNotificationEligibilityValidation(QuerysetEligibilityValidationMixin, AbstractEligibilityValidator):
     NOTIFICATION_NOT_IN_INDICATION_TABLE = "Notification of type {notification} doesn't have representation " \
                                            "in IndicationOfPolicyNotifications table."
-
     NON_ELIGIBLE_HANDLER: Type[NotEligibleNotificationHandler] = NotEligibleNotificationHandler
-
     NotificationCollection = 'QuerySet[Policy]'  # Typing
 
-    BASE_VALIDATION_REJECTION_REASON = \
-        IndicationOfPolicyNotificationsDetails.SendIndicationStatus.NOT_SENT_NO_PERMISSION_FOR_NOTIFICATIONS
-
-    TYPE_VALIDATION_REJECTION_REASON = \
-        IndicationOfPolicyNotificationsDetails.SendIndicationStatus.NOT_PASSED_VALIDATION
-
-    TYPE_VALIDATION_REJECTION_DETAILS = 'Activation on effective day.'
+    @property
+    def registered_validations(self):
+        return [
+            ValidationDefinition(
+                IndicationOfPolicyNotificationsDetails.SendIndicationStatus.NOT_SENT_NO_PERMISSION_FOR_NOTIFICATIONS,
+                'Rejected due to family denied notifications.',
+                self._family_validation),
+            ValidationDefinition(
+                IndicationOfPolicyNotificationsDetails.SendIndicationStatus.NOT_PASSED_VALIDATION,
+                F'Rejected because type of notification of type `{self.type_of_notification}`'
+                F' was sent or is not permitted.',
+                self._notification_type_validation
+            ),
+            ValidationDefinition(
+                IndicationOfPolicyNotificationsDetails.SendIndicationStatus.NOT_PASSED_VALIDATION,
+                'Policy is being activated on day of policy start, only start of policy notification is sent.',
+                self._validate_activate_on_effective_date),
+            ValidationDefinition(
+                IndicationOfPolicyNotificationsDetails.SendIndicationStatus.NOT_SENT_NOTIFICATION_FOR_OBSOLETE_EVENT,
+                'Notification attempt for an event after the time when notification is considered relevant.',
+                self._validate_policy_activation_date),
+            ValidationDefinition(
+                IndicationOfPolicyNotificationsDetails.SendIndicationStatus.NOT_SENT_NOTIFICATION_FOR_OBSOLETE_EVENT,
+                'Notification attempt for an event after the time when notification is considered relevant.',
+                self._validate_policy_renewal_date),
+        ]
 
     def __init__(self, notification_collection: NotificationCollection, type_of_notification: str):
         notification_collection = self._prefetch_details_list(notification_collection)
         super().__init__(notification_collection, type_of_notification)
 
-    def _get_validation_for_notification_type(self, notification_type: str):
-        if notification_type == 'activation_of_policy':
-            return self._validate_activation_of_policy_eligibility
-        return None
+    def _create_ineligible(self, ineligible, validation_definition):
+        return IneligibleObject(
+            policy=ineligible, reason=validation_definition.error_type_code,
+            details=validation_definition.validation_details
+        )
 
-    def _base_eligibility_validation(self, notification_collection, type_of_notification):
-        return self.__base_eligibility(notification_collection, type_of_notification)
+    @classmethod
+    def _validate_activate_on_effective_date(cls, notification_collection, notification_type):
+        """
+        If policy is activated on the effective date and start date notification is enabled only one notification
+        is sent.
+        """
+        if notification_type == 'activation_of_policy' and \
+                PolicyNotificationConfig.eligible_notification_types['starting_of_policy']:
+            return cls.__check_if_starting_on_same_day(notification_collection)
+        else:
+            return notification_collection
 
     def _handle_not_valid_entries(self):
         handler = self.NON_ELIGIBLE_HANDLER(self.type_of_notification)
         handler.save_information_about_not_eligible_policies(self.invalid_collection)
 
-    def __base_eligibility(self, notification_collection, type_of_notification):
-        valid_policies = notification_collection.filter(family__family_notification__approval_of_notification=True)
-        if hasattr(IndicationOfPolicyNotifications, type_of_notification):
-            # Confirm that for given policy notification was not sent, or was sent with error
-            valid_policies = valid_policies.filter(self.__indication_filter(type_of_notification))
-        else:
-            logger.warning(self.NOTIFICATION_NOT_IN_INDICATION_TABLE.format(type_of_notification))
-        return valid_policies
-
-    @classmethod
-    def __indication_filter(cls, type_of_notification):
-        # Confirm that for given policy notification was not sent, or was sent with error
-        indication_not_exit = Q(indication_of_notifications__isnull=True)
-        indication_not_sent = cls.__notification_not_sent_filter(type_of_notification)
-        indication_failed = cls.__notification_failed_filter(type_of_notification)
-        return indication_not_exit | indication_not_sent | indication_failed
-
-    @classmethod
-    def __notification_not_sent_filter(cls, type_of_notification):
-        return Q(**{f"indication_of_notifications__{type_of_notification}__isnull": True})
-
-    @classmethod
-    def __notification_failed_filter(cls, type_of_notification):
-        return Q(**{
-            f"indication_of_notifications__{type_of_notification}":
-                PolicyNotificationConfig.UNSUCCESSFUL_NOTIFICATION_ATTEMPT_DATE
-        }) & Q(**{
-            f"indication_of_notifications__details__status":
-                IndicationOfPolicyNotificationsDetails.SendIndicationStatus.NOT_SENT_DUE_TO_ERROR,
-            f"indication_of_notifications__details__notification_type": type_of_notification
-        })
-
-    @classmethod
-    def _validate_activation_of_policy_eligibility(cls, policies_collection: NotificationCollection):
-        if PolicyNotificationConfig.eligible_notification_types['starting_of_policy']:
-            return cls.__check_if_starting_on_same_day(policies_collection)
-        else:
-            return policies_collection
+    def _prefetch_details_list(self, notification_collection):
+        return notification_collection.select_related('indication_of_notifications') \
+            .prefetch_related(Prefetch(
+                'indication_of_notifications__details',
+                queryset=IndicationOfPolicyNotificationsDetails.objects.filter(validity_to__isnull=True),
+                to_attr='details_list')
+        ).all()
 
     @classmethod
     def __check_if_starting_on_same_day(cls, policies_collection: NotificationCollection):
@@ -95,10 +91,39 @@ class PolicyNotificationEligibilityValidation(QuerysetEligibilityValidationMixin
         today = datetime.now().date()
         return policies_collection.filter(~Q(effective_date=today))
 
-    def _prefetch_details_list(self, notification_collection):
-        return notification_collection.select_related('indication_of_notifications') \
-            .prefetch_related(Prefetch(
-            'indication_of_notifications__details',
-            queryset=IndicationOfPolicyNotificationsDetails.objects.filter(validity_to__isnull=True),
-            to_attr='details_list'
-        )).all()
+    @classmethod
+    def _family_validation(cls, notification_collection, type_of_notification):
+        validation = notification_collection
+        return validation.filter(family__family_notification__approval_of_notification=True).all()
+
+    @classmethod
+    def _notification_type_validation(cls, notification_collection, type_of_notification):
+        valid_policies = notification_collection
+        if hasattr(IndicationOfPolicyNotifications, type_of_notification):
+            # Confirm that for given policy notification was not sent, or was sent with error
+            valid_policies = valid_policies.filter(cls.__indication_filter(type_of_notification))
+        else:
+            logger.warning(cls.NOTIFICATION_NOT_IN_INDICATION_TABLE.format(type_of_notification))
+        return valid_policies
+
+    @classmethod
+    def _validate_policy_activation_date(cls, notification_collection, type_of_notification):
+        date_from = datetime.today() - timedelta(
+            days=PolicyNotificationConfig.policy_activation_relevance_maximum_days_timedelta)
+        if type_of_notification == 'activation_of_policy':
+            return notification_collection.filter(validity_from__gte=date_from)
+        else:
+            return notification_collection
+
+    @classmethod
+    def _validate_policy_renewal_date(cls, notification_collection, type_of_notification):
+        date_from = datetime.today() - timedelta(
+            days=PolicyNotificationConfig.policy_renewal_relevance_maximum_days_timedelta)
+        if type_of_notification == 'renewal_of_policy':
+            return notification_collection.filter(validity_from__gte=date_from)
+        else:
+            return notification_collection
+
+    @classmethod
+    def __indication_filter(cls, type_of_notification):
+        return get_notification_indication_filter(type_of_notification)

--- a/policy_notification/schema.py
+++ b/policy_notification/schema.py
@@ -5,6 +5,7 @@ from core.schema import signal_mutation_module_after_mutating
 from insuree.models import Family, Insuree
 from insuree.signals import signal_before_family_query
 from graphene_django.filter import DjangoFilterConnectionField
+from django.db.models import Q
 
 from policy_notification.gql_queries import FamilyNotificationGQLType
 from policy_notification.services import update_family_notification_policy, create_family_notification_policy, delete_family_notification_policy
@@ -79,7 +80,6 @@ def on_family_query_filter(sender, **kwargs):
         mode = mode.get('value', 0)
         return communication_approval_filter(mode)
     return Q()
-
 
 
 def bind_signals():

--- a/policy_notification/tests/Triggers/sms_trigger_activated_test.py
+++ b/policy_notification/tests/Triggers/sms_trigger_activated_test.py
@@ -19,6 +19,14 @@ class TestActivePolicyTrigger(BaseTriggerTestCase):
         self.assertEqual(altered_policies[0], self.policy.id)
 
     @patch('policy_notification.notification_triggers.notification_triggers.datetime')
+    def test_find_activated_policies_old(self, mocked_dt):
+        mocked_dt.now.return_value = datetime(2021, 6, 2)
+        self.policy.validity_from = datetime(2021, 5, 2)
+        altered_policies = self.TEST_TRIGGER_DETECTOR.find_activated_policies()
+        self.assertEqual(len(altered_policies), 1)
+        self.assertEqual(altered_policies[0], self.policy.id)
+
+    @patch('policy_notification.notification_triggers.notification_triggers.datetime')
     def test_find_activated_policies_recently_changed(self, mocked_dt):
         mocked_dt.now.return_value = datetime(2021, 6, 2)
         self._create_policy_history()

--- a/policy_notification/tests/dispatcher_test.py
+++ b/policy_notification/tests/dispatcher_test.py
@@ -1,3 +1,4 @@
+import datetime
 from datetime import timedelta, date
 from unittest.mock import patch, PropertyMock
 
@@ -72,7 +73,9 @@ class DispatcherTest(TestCase):
         }
 
     @patch('policy_notification.notification_triggers.NotificationTriggerEventDetectors.find_activated_policies')
-    def test_send_notification_for_eligible_policies(self, find_policies):
+    @patch('policy_notification.notification_eligibility_validators.notification_eligibility_validation.datetime')
+    def test_send_notification_for_eligible_policies(self, mocked_dt, find_policies):
+        mocked_dt.today.return_value = datetime(2021, 5, 30, 12)
         find_policies.return_value = [self.policy.id]
         with patch.object(TextNotificationProvider, 'send_notification',
                           return_value=NotificationSendingResult(success=True)) as mock_sent:
@@ -91,6 +94,28 @@ class DispatcherTest(TestCase):
                                 PolicyNotificationConfig.UNSUCCESSFUL_NOTIFICATION_ATTEMPT_DATE)
             self.assertEqual(details_status,
                              IndicationOfPolicyNotificationsDetails.SendIndicationStatus.SENT_SUCCESSFULLY)
+
+    @patch('policy_notification.notification_triggers.NotificationTriggerEventDetectors.find_activated_policies')
+    @patch('policy_notification.notification_eligibility_validators.notification_eligibility_validation.datetime')
+    def test_not_send_notification_for_non_eligible_policies(self, mocked_dt, find_policies):
+        mocked_dt.today.return_value = datetime(2021, 6, 20, 20)
+        find_policies.return_value = [self.policy.id]
+        with patch.object(TextNotificationProvider, 'send_notification',
+                          return_value=NotificationSendingResult(success=True)) as mock_sent:
+            provider = TextNotificationProvider()
+
+            dispatcher = NotificationDispatcher(provider, self.TEST_TEMPLATES(), self.TEST_TRIGGER_DETECTOR())
+            dispatcher.send_notification_new_active_policies()
+            details_status = self.policy.indication_of_notifications.details\
+                .get(notification_type='activation_of_policy').status
+
+            mock_sent.assert_not_called()
+            self.assertIsNotNone(self.policy.indication_of_notifications.activation_of_policy)
+            self.assertEqual(self.policy.indication_of_notifications.activation_of_policy,
+                             PolicyNotificationConfig.UNSUCCESSFUL_NOTIFICATION_ATTEMPT_DATE)
+            self.assertEqual(
+                details_status,
+                IndicationOfPolicyNotificationsDetails.SendIndicationStatus.NOT_SENT_NOTIFICATION_FOR_OBSOLETE_EVENT)
 
     @patch('policy_notification.notification_triggers.NotificationTriggerEventDetectors.find_activated_policies')
     def test_send_notification_for_eligible_policies_already_sent(self, find_policies):
@@ -135,6 +160,11 @@ class DispatcherTest(TestCase):
                 IndicationOfPolicyNotificationsDetails.SendIndicationStatus.NOT_SENT_NO_PERMISSION_FOR_NOTIFICATIONS
             )
 
+            self.assertEqual(
+                self.policy.indication_of_notifications.details.get(notification_type='activation_of_policy').details,
+                "Rejected due to family denied notifications."
+            )
+
             # Resend for same policy after accepting notifications should fails
             self.test_family.family_notification.approval_of_notification = True
             self.test_family.family_notification.save()
@@ -148,7 +178,10 @@ class DispatcherTest(TestCase):
             mock_sent.assert_not_called()
 
     @patch('policy_notification.notification_triggers.NotificationTriggerEventDetectors.find_activated_policies')
-    def test_send_notification_for_eligible_policies_resend_after_sending_error(self, find_policies):
+    @patch('policy_notification.notification_eligibility_validators'
+           '.notification_eligibility_validation.datetime')
+    def test_send_notification_for_eligible_policies_resend_after_sending_error(self, dt_mock, find_policies):
+        dt_mock.today.return_value = datetime(2021, 6, 1, 1)
         self.test_family.family_notification.approval_of_notification = False
         self.test_family.family_notification.save()
 
@@ -156,7 +189,6 @@ class DispatcherTest(TestCase):
         with patch.object(TextNotificationProvider, 'send_notification',
                           return_value=NotificationSendingResult(success=True)) as mock_sent:
             provider = TextNotificationProvider()
-
             dispatcher = NotificationDispatcher(provider, self.TEST_TEMPLATES(), self.TEST_TRIGGER_DETECTOR())
             dispatcher.send_notification_new_active_policies()
             # Override status
@@ -204,5 +236,7 @@ class DispatcherTest(TestCase):
                 self.assertEqual(
                     detail.status, IndicationOfPolicyNotificationsDetails.SendIndicationStatus.NOT_PASSED_VALIDATION
                 )
-                self.assertEqual(detail.details, 'Activation on effective day.')
+                expected_details = 'Policy is being activated on day of policy start, ' \
+                                   'only start of policy notification is sent.'
+                self.assertEqual(detail.details, expected_details)
                 mock_sent.assert_not_called()


### PR DESCRIPTION
TICKET: [OTC-641](https://openimis.atlassian.net/browse/OTC-641)

Changes: 
- Added time restriction for activated and renewed policies. If given activation is older than 5 (by default, can be configured) days, it'll not be sent to family, instead it'll be marked as failed and proper information will be stored in indication details. 
- Refactored `NotificationEligibilityValidation` class, it's easier to extend query validation and save detailed information if validation failed. 
- Adjusted unit tests.   