### PR TITLE
fix UnboundLocalError when creating families

### DIFF
--- a/policy_notification/schema.py
+++ b/policy_notification/schema.py
@@ -24,15 +24,15 @@ def on_family_create_mutation(mutation_args):
         family_uuid = Family.objects.get(head_insuree=head_of_family, validity_to__isnull=True).uuid
         if not family_uuid:
             return []
+        family_notification_policy = mutation_args['data'].get('contribution', {}).get('PolicyNotification', {})
+        create_family_notification_policy(family_uuid, family_notification_policy)
+        
     except (Family.DoesNotExist, Insuree.DoesNotExist) as e:
         logger.warning(F"Family with head insuree with chf {head_of_family_chf} not found, FamilyNotification was not created")
     except Exception as e:
         import traceback
         logger.error("Error ocurred during creating new familySMS, traceback: ")
         traceback.print_exc()
-
-    family_notification_policy = mutation_args['data'].get('contribution', {}).get('PolicyNotification', {})
-    create_family_notification_policy(family_uuid, family_notification_policy)
     return []
 
 


### PR DESCRIPTION
This PR fixes an UnboundLocalError that occurred when creating a family, specifically when the head_insuree was not found and family_uuid was never assigned.
The following error was raised during execution:

`UnboundLocalError: local variable 'family_uuid' referenced before assignment`

The call to `create_family_notification_policy(...)` was moved inside the try block to ensure family_uuid is only used when properly assigned.